### PR TITLE
Fix compilation with clang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04]
-        compiler: [gcc]
+        compiler: [gcc,clang]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04]
         compiler: [gcc,clang]
+        build-type: [Release, RelWithDebInfo]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -56,15 +57,15 @@ jobs:
     - name: Install dependencies
       uses: jrl-umi3218/github-actions/install-dependencies@master
       with:
-        compiler: gcc
-        build-type: RelWithDebInfo
+        compiler: ${{ matrix.compiler }}
+        build-type: ${{ matrix.build-type }}
         ubuntu: |
           apt: hrpsys-base libmc-rtc-dev
     - name: Build and test
       uses: jrl-umi3218/github-actions/build-cmake-project@master
       with:
-        compiler: gcc
-        build-type: RelWithDebInfo
+        compiler: ${{ matrix.compiler }}
+        build-type: ${{ matrix.build-type }}
     - name: Slack Notification
       if: failure()
       uses: archive/github-actions-slack@master

--- a/src/client/MCUDPControl.cpp
+++ b/src/client/MCUDPControl.cpp
@@ -31,7 +31,7 @@ void cli(mc_control::MCGlobalController & ctl)
     ss >> token;
     if(token == "stop")
     {
-      LOG_INFO("Stopping connection")
+      mc_rtc::log::info("Stopping connection");
       running = false;
     }
     else if(token == "hs" || token == "GoToHalfSitPose" || token == "half_sitting")
@@ -100,7 +100,7 @@ int main(int argc, char * argv[])
 
   if(vm.count("encoderVelocity"))
   {
-    LOG_INFO("[UDP] Sending/Receiving encoder velocities");
+    mc_rtc::log::info("[UDP] Sending/Receiving encoder velocities");
     withEncoderVelocity = true;
   }
 
@@ -111,9 +111,9 @@ int main(int argc, char * argv[])
 
   if(mc_rtc::MC_RTC_VERSION != mc_rtc::version())
   {
-    LOG_ERROR("mc_rtc_ticker was compiled with "
-              << mc_rtc::MC_RTC_VERSION << " but mc_rtc is at version " << mc_rtc::version()
-              << ", you might face subtle issues or unexpected crashes, please recompile mc_rtc_ticker")
+    mc_rtc::log::error("mc_udp was compiled with {} but mc_rtc is at version {}, you might face subtle issues or "
+                       "unexpected crashes, please recompile mc_udp",
+                       mc_rtc::MC_RTC_VERSION, mc_rtc::version());
   }
 
   mc_control::MCGlobalController::GlobalConfiguration gconfig(conf_file, nullptr);
@@ -128,17 +128,17 @@ int main(int argc, char * argv[])
   mc_control::MCGlobalController controller(gconfig);
   if(singleClient)
   {
-    LOG_INFO("Connect UDP client to " << host << ":" << port)
+    mc_rtc::log::info("Connect UDP client to {};{}", host, port);
   }
   else
   {
-    LOG_INFO("Connecting UDP sensors client to " << host << ":" << port)
+    mc_rtc::log::info("Connecting UDP sensors client to {}:{}", host, port);
   }
   mc_udp::Client sensorsClient(host, port);
   mc_udp::Client * controlClientPtr = &sensorsClient;
   if(!singleClient)
   {
-    LOG_INFO("Connecting UDP control client to " << host << ":" << port + 1)
+    mc_rtc::log::info("Connecting UDP control client to {}:{}", host, port + 1);
     controlClientPtr = new mc_udp::Client(host, port + 1);
   }
   mc_udp::Client & controlClient = *controlClientPtr;
@@ -196,11 +196,11 @@ int main(int argc, char * argv[])
           alphaInit = ignoredVelocityValues[jN];
         }
         ignoredVelocities[idx] = alphaInit;
-        LOG_WARNING("[UDP] Joint " << jN << " is ignored, value = " << qInit << ", velocity=" << alphaInit);
+        mc_rtc::log::warning("[UDP] Joint {} is ignored, value = {}, velocity= {}", jN, qInit, alphaInit);
       }
       else
       {
-        LOG_WARNING("[UDP] Ignored joint " << jN << " is not present in robot " << controller.robot().name());
+        mc_rtc::log::warning("[UDP] Ignored joint {} is not present in robot ", jN, controller.robot().name());
       }
     }
   }
@@ -304,7 +304,7 @@ int main(int argc, char * argv[])
         {
           alphaOut.resize(rjo.size());
         }
-        LOG_INFO("[MCUDPControl] Init duration " << init_dt.count())
+        mc_rtc::log::info("[MCUDPControl] Init duration {}", init_dt.count());
         sensorsClient.init();
         if(!singleClient)
         {
@@ -315,8 +315,8 @@ int main(int argc, char * argv[])
       {
         if(prev_id + 1 != sc.id)
         {
-          LOG_WARNING("[MCUDPControl] Missed one or more sensors reading (previous id: "
-                      << prev_id << ", current id: " << sensorsClient.sensors().id << ")")
+          mc_rtc::log::warning("[MCUDPControl] Missed one or more sensors reading (previous id: {}, current id: {})",
+                               prev_id, sensorsClient.sensors().id);
         }
         if(controller.run())
         {

--- a/src/server/openrtm/MCUDPControl.h
+++ b/src/server/openrtm/MCUDPControl.h
@@ -6,15 +6,21 @@
 
 #include <mc_udp/server/Server.h>
 
-#include <chrono>
-#include <memory>
+// clang-format off
+// Clang-format was disabled on purpose here to prevent it from re-ordering the includes
+// These must come first
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+
 #include <rtm/CorbaPort.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/Manager.h>
-#include <rtm/idl/BasicDataTypeSkel.h>
-#include <rtm/idl/ExtendedDataTypesSkel.h>
+
+#include <chrono>
+#include <memory>
+// clang-format on
 
 class MCUDPControl : public RTC::DataFlowComponentBase
 {

--- a/src/server/openrtm/MCUDPSensors.h
+++ b/src/server/openrtm/MCUDPSensors.h
@@ -6,15 +6,20 @@
 
 #include <mc_udp/server/Server.h>
 
-#include <chrono>
-#include <memory>
+// clang-format off
+// Clang-format was disabled on purpose here to prevent it from re-ordering the includes
+// These must come first
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/ExtendedDataTypesSkel.h>
+
 #include <rtm/CorbaPort.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/Manager.h>
-#include <rtm/idl/BasicDataTypeSkel.h>
-#include <rtm/idl/ExtendedDataTypesSkel.h>
+#include <chrono>
+#include <memory>
+// clang-format off
 
 class MCUDPSensors : public RTC::DataFlowComponentBase
 {


### PR DESCRIPTION
This PR fixes compilation with clang, and sets up clang build in CI.

These two includes must come first
```
#include <rtm/idl/BasicDataTypeSkel.h>
#include <rtm/idl/ExtendedDataTypesSkel.h>
```

If not the type conversions of openrtm fail to compile (for some strange reason GCC didn't have a problem with this).

Additionally this adapts logging to spdlog.