### PR TITLE
Correct use of linearAcceleration instead of angularAcceleration

### DIFF
--- a/include/mc_udp/data/RobotSensors.h
+++ b/include/mc_udp/data/RobotSensors.h
@@ -34,8 +34,8 @@ struct RobotSensors
   double orientation[3];
   /** Angular velocity sensor */
   double angularVelocity[3];
-  /** Angular acceleration */
-  double angularAcceleration[3];
+  /** Linear acceleration */
+  double linearAcceleration[3];
   /** Position of IMU (pIn) **/
   double position[3];
   /** Position of floating base **/

--- a/src/client/MCUDPControl.cpp
+++ b/src/client/MCUDPControl.cpp
@@ -252,30 +252,27 @@ int main(int argc, char * argv[])
           sensorsClient.sensors().angularVelocity[2];
       controller.setSensorAngularVelocity(vel);
       Eigen::Vector3d acc;
-      acc << sensorsClient.sensors().angularAcceleration[0], sensorsClient.sensors().angularAcceleration[1],
-          sensorsClient.sensors().angularAcceleration[2];
-      controller.setSensorAcceleration(acc);
+      acc << sensorsClient.sensors().linearAcceleration[0], sensorsClient.sensors().linearAcceleration[1],
+          sensorsClient.sensors().linearAcceleration[2];
+      controller.setSensorLinearAcceleration(acc);
 
       // Floating base sensor
       if(controller.robot().hasBodySensor("FloatingBase"))
       {
         controller.setSensorPositions(
-            controller.robot(),
             {{"FloatingBase", {sc.floatingBasePos[0], sc.floatingBasePos[1], sc.floatingBasePos[2]}}});
         Eigen::Vector3d fbRPY;
         controller.setSensorOrientations(
-            controller.robot(),
             {{"FloatingBase", Eigen::Quaterniond(mc_rbdyn::rpyToMat(
                                   {sc.floatingBaseRPY[0], sc.floatingBaseRPY[1], sc.floatingBaseRPY[2]}))}});
         controller.setSensorAngularVelocities(
-            controller.robot(),
             {{"FloatingBase", {sc.floatingBaseVel[0], sc.floatingBaseVel[1], sc.floatingBaseVel[2]}}});
         controller.setSensorLinearVelocities(
-            controller.robot(),
             {{"FloatingBase", {sc.floatingBaseVel[3], sc.floatingBaseVel[4], sc.floatingBaseVel[5]}}});
-        controller.setSensorAccelerations(
-            controller.robot(),
+        controller.setSensorAngularAccelerations(
             {{"FloatingBase", {sc.floatingBaseAcc[0], sc.floatingBaseAcc[1], sc.floatingBaseAcc[2]}}});
+        controller.setSensorLinearAccelerations(
+            {{"FloatingBase", {sc.floatingBaseAcc[3], sc.floatingBaseAcc[4], sc.floatingBaseAcc[5]}}});
       }
 
       for(const auto & fs : sc.fsensors)

--- a/src/data/RobotSensors.cpp
+++ b/src/data/RobotSensors.cpp
@@ -38,7 +38,7 @@ size_t RobotSensors::size() const
       sizeof(uint64_t) + torques.size() * sizeof(double) +
       // Size of fsensors
       fsensorsSize() +
-      // Size of orientation + angularVelocity + angularAcceleration
+      // Size of orientation + angularVelocity + linearAcceleration
       9 * sizeof(double) +
       // Size of position (pIn)
       3 * sizeof(double) +
@@ -105,7 +105,7 @@ void RobotSensors::toBuffer(uint8_t * buffer) const
   }
   memcpy_advance(buffer, orientation, 3 * sizeof(double), offset);
   memcpy_advance(buffer, angularVelocity, 3 * sizeof(double), offset);
-  memcpy_advance(buffer, angularAcceleration, 3 * sizeof(double), offset);
+  memcpy_advance(buffer, linearAcceleration, 3 * sizeof(double), offset);
   memcpy_advance(buffer, position, 3 * sizeof(double), offset);
   memcpy_advance(buffer, floatingBasePos, 3 * sizeof(double), offset);
   memcpy_advance(buffer, floatingBaseRPY, 3 * sizeof(double), offset);
@@ -156,7 +156,7 @@ void RobotSensors::fromBuffer(uint8_t * buffer)
   }
   memcpy_advance(orientation, buffer, 3 * sizeof(double), offset);
   memcpy_advance(angularVelocity, buffer, 3 * sizeof(double), offset);
-  memcpy_advance(angularAcceleration, buffer, 3 * sizeof(double), offset);
+  memcpy_advance(linearAcceleration, buffer, 3 * sizeof(double), offset);
   memcpy_advance(position, buffer, 3 * sizeof(double), offset);
   memcpy_advance(floatingBasePos, buffer, 3 * sizeof(double), offset);
   memcpy_advance(floatingBaseRPY, buffer, 3 * sizeof(double), offset);

--- a/src/server/openrtm/MCUDPSensors.cpp
+++ b/src/server/openrtm/MCUDPSensors.cpp
@@ -170,13 +170,13 @@ RTC::ReturnCode_t MCUDPSensors::onExecute(RTC::UniqueId ec_id)
   {
     m_accInIn.read();
 #ifdef MC_UDP_OPENRTM_LEGACY
-    server_.sensors().angularAcceleration[0] = m_accIn.data[0];
-    server_.sensors().angularAcceleration[1] = m_accIn.data[1];
-    server_.sensors().angularAcceleration[2] = m_accIn.data[2];
+    server_.sensors().linearAcceleration[0] = m_accIn.data[0];
+    server_.sensors().linearAcceleration[1] = m_accIn.data[1];
+    server_.sensors().linearAcceleration[2] = m_accIn.data[2];
 #else
-    server_.sensors().angularAcceleration[0] = m_accIn.data.ax;
-    server_.sensors().angularAcceleration[1] = m_accIn.data.ay;
-    server_.sensors().angularAcceleration[2] = m_accIn.data.az;
+    server_.sensors().linearAcceleration[0] = m_accIn.data.ax;
+    server_.sensors().linearAcceleration[1] = m_accIn.data.ay;
+    server_.sensors().linearAcceleration[2] = m_accIn.data.az;
 #endif
   }
   if(m_taucInIn.isNew())


### PR DESCRIPTION
- The filed named `angularAcceleration` was actually used to provide the `linearAcceleration` of the IMU => rename `angularAcceleration` -> `linearAcceleration`
- Adapt to the changes in sensor interface https://github.com/jrl-umi3218/mc_rtc/pull/61