### PR TITLE
Support GCC 4.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,13 @@ _SETUP_PROJECT_UNINSTALL()
 option(BUILD_TESTING "Build unit tests" ON)
 option(BUILD_MC_RTC_CLIENT "Build mc_rtc client" ON)
 option(BUILD_OPENRTM_SERVER "Build OpenRTM server component" ON)
+option(BUILD_LEGACY_OPENRTM_SERVER "Build OpenRTM server with c++0x" OFF)
 option(BUILD_DUMMY_CLIENT "Build dummy client" OFF)
 option(BUILD_DUMMY_SERVER "Build dummy server" OFF)
 
 add_subdirectory(src)
 
-if(PYTHON_BINDING)
+if(PYTHON_BINDING AND NOT BUILD_LEGACY_OPENRTM_SERVER)
   add_subdirectory(binding/python)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ option(BUILD_DUMMY_SERVER "Build dummy server" OFF)
 
 add_subdirectory(src)
 
-if(PYTHON_BINDING AND NOT BUILD_LEGACY_OPENRTM_SERVER)
+if(PYTHON_BINDING)
   add_subdirectory(binding/python)
 endif()
 

--- a/include/mc_udp/data/MultiRobotMessage.h
+++ b/include/mc_udp/data/MultiRobotMessage.h
@@ -32,8 +32,8 @@ struct MultiRobotMessage
   size_t fromBuffer(uint8_t * buffer);
 };
 
-using MultiRobotControl = MultiRobotMessage<RobotControl>;
-using MultiRobotSensors = MultiRobotMessage<RobotSensors>;
+typedef MultiRobotMessage<RobotControl> MultiRobotControl;
+typedef MultiRobotMessage<RobotSensors> MultiRobotSensors;
 
 } // namespace mc_udp
 

--- a/include/mc_udp/data/MultiRobotMessage.hpp
+++ b/include/mc_udp/data/MultiRobotMessage.hpp
@@ -9,15 +9,15 @@ template<typename MsgT>
 size_t MultiRobotMessage<MsgT>::size() const
 {
   size_t ret = sizeof(uint64_t); // Number of robots in the message
-  for(const auto & m : messages)
+  for(auto it = messages.cbegin(); it != messages.cend(); it++)
   {
     ret +=
         // Length of robot name
         sizeof(uint64_t) +
         // Name data
-        m.first.size() * sizeof(char) +
+        it->first.size() * sizeof(char) +
         // Length of message for that robot
-        m.second.size();
+        it->second.size();
   }
   return ret;
 }
@@ -28,10 +28,10 @@ size_t MultiRobotMessage<MsgT>::toBuffer(uint8_t * buffer) const
   size_t offset = 0;
   uint64_t tmp = messages.size();
   utils::memcpy_advance(buffer, &tmp, sizeof(uint64_t), offset);
-  for(const auto & m : messages)
+  for(auto it = messages.cbegin(); it != messages.cend(); it++)
   {
-    utils::toBuffer(buffer, m.first, offset);
-    offset += m.second.toBuffer(buffer + offset);
+    utils::toBuffer(buffer, it->first, offset);
+    offset += it->second.toBuffer(buffer + offset);
   }
   return offset;
 }

--- a/include/mc_udp/data/RobotControl.h
+++ b/include/mc_udp/data/RobotControl.h
@@ -6,6 +6,7 @@
 
 #include <mc_udp/data/api.h>
 
+#include <stdint.h>
 #include <string>
 #include <vector>
 

--- a/include/mc_udp/data/RobotSensors.h
+++ b/include/mc_udp/data/RobotSensors.h
@@ -6,6 +6,7 @@
 
 #include <mc_udp/data/api.h>
 
+#include <stdint.h>
 #include <string>
 #include <vector>
 

--- a/include/mc_udp/data/utils.h
+++ b/include/mc_udp/data/utils.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstring>
+#include <stdint.h>
 #include <string>
 #include <vector>
 

--- a/include/mc_udp/server/Server.h
+++ b/include/mc_udp/server/Server.h
@@ -79,9 +79,9 @@ private:
 private:
   MultiRobotControl control_;
   MultiRobotSensors sensors_;
-  int socket_ = 0;
-  bool initClient_ = false;
-  bool waitInit_ = false;
+  int socket_;
+  bool initClient_;
+  bool waitInit_;
   sockaddr_in client_;
   socklen_t clientAddrLen_;
   std::vector<uint8_t> recvData_;

--- a/include/mc_udp/server/Server.h
+++ b/include/mc_udp/server/Server.h
@@ -74,6 +74,9 @@ struct MC_UDP_SERVER_DLLAPI Server
   void restart(int port);
 
 private:
+  void init(); /** delegating constructor */
+
+private:
   MultiRobotControl control_;
   MultiRobotSensors sensors_;
   int socket_;

--- a/include/mc_udp/server/Server.h
+++ b/include/mc_udp/server/Server.h
@@ -79,14 +79,14 @@ private:
 private:
   MultiRobotControl control_;
   MultiRobotSensors sensors_;
-  int socket_;
+  int socket_ = 0;
+  bool initClient_ = false;
+  bool waitInit_ = false;
   sockaddr_in client_;
   socklen_t clientAddrLen_;
   std::vector<uint8_t> recvData_;
   std::vector<uint8_t> sendData_;
   void start(int port);
-  bool initClient_;
-  bool waitInit_;
   std::string id_;
 #ifdef WIN32
   WSAData wsaData_;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,9 @@ set_target_properties(mc_udp_data PROPERTIES COMPILE_FLAGS "-DMC_UDP_DATA_EXPORT
 target_include_directories(mc_udp_data PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
+if(BUILD_LEGACY_OPENRTM_SERVER)
+  target_compile_options(mc_udp_data PUBLIC -std=c++0x)
+endif()
 
 add_subdirectory(client)
 add_subdirectory(server)

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -32,7 +32,7 @@ Client::Client(const std::string & host, int port) : recvData_(2048, 0), sendDat
   auto hp = gethostbyname(host.c_str());
   if(!hp)
   {
-    MC_UDP_ERROR_AND_THROW(std::runtime_error, "Faile to resolve host (" << host << "): " << strerror(h_errno));
+    MC_UDP_ERROR_AND_THROW(std::runtime_error, "Failed to resolve host (" << host << "): " << strerror(h_errno));
   }
   memset(&server_, 0, sizeof(server_));
   server_.sin_family = AF_INET;

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -8,6 +8,7 @@
 #include <mc_udp/data/Init.h>
 #include <mc_udp/logging.h>
 
+#include <errno.h>
 #include <stdexcept>
 #include <string.h>
 

--- a/src/client/MCUDPControl.cpp
+++ b/src/client/MCUDPControl.cpp
@@ -375,7 +375,7 @@ int main(int argc, char * argv[])
         {
           for(const auto & robot : controller.controller().robots())
           {
-            const auto & rjo = controller.ref_joint_order();
+            const auto & rjo = robot.refJointOrder();
             if(rjo.size() == 0)
             {
               continue;

--- a/src/data/RobotSensors.cpp
+++ b/src/data/RobotSensors.cpp
@@ -23,8 +23,8 @@ void RobotSensors::fsensor(const std::string & name, double data[6])
   }
   ForceSensor fs;
   fs.name = name;
-  fsensors.push_back(fs);
   std::memcpy(fs.reading, data, 6 * sizeof(double));
+  fsensors.push_back(fs);
 }
 
 size_t RobotSensors::size() const

--- a/src/data/RobotSensors.cpp
+++ b/src/data/RobotSensors.cpp
@@ -21,9 +21,10 @@ void RobotSensors::fsensor(const std::string & name, double data[6])
       return;
     }
   }
-  fsensors.emplace_back();
-  fsensors.back().name = name;
-  std::memcpy(fsensors.back().reading, data, 6 * sizeof(double));
+  ForceSensor fs;
+  fs.name = name;
+  fsensors.push_back(fs);
+  std::memcpy(fs.reading, data, 6 * sizeof(double));
 }
 
 size_t RobotSensors::size() const
@@ -58,7 +59,7 @@ size_t RobotSensors::fsensorsSize() const
   size_t ret = sizeof(uint64_t); // Lenght of fSensors
   for(size_t i = 0; i < fsensors.size(); ++i)
   {
-    const auto & fsensor = fsensors[i];
+    const ForceSensor & fsensor = fsensors[i];
     ret += sizeof(uint64_t) + fsensor.name.size() * sizeof(char) + 6 * sizeof(double);
   }
   return ret;
@@ -77,9 +78,9 @@ static void toBuffer(uint8_t * dest, const std::vector<ForceSensor> & src, size_
 {
   uint64_t size = src.size();
   memcpy_advance(dest, &size, sizeof(uint64_t), offset);
-  for(const auto & fs : src)
+  for(size_t i = 0; i < src.size(); i++)
   {
-    toBuffer(dest, fs, offset);
+    toBuffer(dest, src[i], offset);
   }
 }
 
@@ -118,9 +119,9 @@ static void fromBuffer(std::vector<ForceSensor> & dest, const uint8_t * src, siz
   uint64_t size = 0;
   memcpy_advance(&size, src, sizeof(uint64_t), offset);
   dest.resize(size);
-  for(auto & fs : dest)
+  for(size_t i = 0; i < dest.size(); i++)
   {
-    fromBuffer(fs, src, offset);
+    fromBuffer(dest[i], src, offset);
   }
 }
 

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -19,12 +19,12 @@
 namespace mc_udp
 {
 
-Server::Server() : socket_(0), recvData_(1024, 0), sendData_(1024, 0), initClient_(false), waitInit_(false)
+Server::Server() : recvData_(1024, 0), sendData_(1024, 0)
 {
   init();
 }
 
-Server::Server(int port)
+Server::Server(int port) : recvData_(1024, 0), sendData_(1024, 0)
 {
   init();
   start(port);

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -8,6 +8,7 @@
 #include <mc_udp/data/Init.h>
 #include <mc_udp/logging.h>
 
+#include <errno.h>
 #include <stdexcept>
 #include <string.h>
 
@@ -20,14 +21,20 @@ namespace mc_udp
 
 Server::Server() : socket_(0), recvData_(1024, 0), sendData_(1024, 0), initClient_(false), waitInit_(false)
 {
+  init();
+}
+
+Server::Server(int port)
+{
+  init();
+  start(port);
+}
+
+void Server::init()
+{
 #ifdef WIN32
   WSAStartup(MAKEWORD(2, 2), &wsaData_);
 #endif
-}
-
-Server::Server(int port) : Server()
-{
-  start(port);
 }
 
 Server::~Server()
@@ -57,9 +64,9 @@ bool Server::recv()
     else if(length == sizeof(Init) * sizeof(uint8_t))
     {
       MC_UDP_INFO(id_ << " Start streaming data to client")
-      for(auto & m : sensors().messages)
+      for(auto it = sensors().messages.begin(); it != sensors().messages.end(); it++)
       {
-        m.second.id = 0;
+        it->second.id = 0;
       }
       initClient_ = false;
     }

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -19,12 +19,12 @@
 namespace mc_udp
 {
 
-Server::Server() : recvData_(1024, 0), sendData_(1024, 0)
+Server::Server() : socket_(0), initClient_(false), waitInit_(false), recvData_(1024, 0), sendData_(1024, 0)
 {
   init();
 }
 
-Server::Server(int port) : recvData_(1024, 0), sendData_(1024, 0)
+Server::Server(int port) : socket_(0), initClient_(false), waitInit_(false), recvData_(1024, 0), sendData_(1024, 0)
 {
   init();
   start(port);


### PR DESCRIPTION
This PR allows building the OpenRTM server with GCC 4.4 that only has partial C++11 support:

- Anything shared by the server and client (`data/`) may only use the following subset of C++11: https://gcc.gnu.org/gcc-4.4/cxx0x_status.html. In particular, there is no support for range-based for loops, no `emplace_back` and using declarations are invalid. Otherwise `auto` is supported.
- The `uint*_t` and such types do not exist by default and must be included with `stdint.h`. Note: they also exist in the `<cstdint>` header, but in this case we would need to use `std::uint*_t` instead.
- I haven't added a mechanism to detect if the compiler has full c++11 support or not. Instead there is a new option `BUILD_LEGACY_OPENRTM_SERVER` that should be put to `ON` when building on HRP4LIRMM. I don't think it's worth spending more effort as it's highly unlikely that we'll ever build the OpenRTM on a setup that old anywhere else :face_with_head_bandage: 
- Fixes a bug for multi-robot and ignored joints

This has been successfully compiled and runs on the robot, although @SaeidSamadi has reported strange behaviours on HRP4 that may or may not be related to the update of mc_udp. We can wait until this has been properly investigated before merging this.